### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,8 @@ ci-run: deps-act
 release:
 	@bash -c 'read -p "New tag (current: $(VERSION)): " newtag && \
 		echo "$$newtag" | grep -qE "^v[0-9]+\.[0-9]+\.[0-9]+$$" || { echo "Error: Tag must match vN.N.N"; exit 1; } && \
+		if git rev-parse -q --verify "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists locally. Pick a new version or delete it: git tag -d $$newtag"; exit 1; fi && \
+		if git ls-remote --exit-code --tags origin "refs/tags/$$newtag" >/dev/null 2>&1; then echo "ERROR: tag $$newtag already exists on origin. Pick a new version."; exit 1; fi && \
 		echo -n "Create and push $$newtag? [y/N] " && read ans && [ "$${ans:-N}" = y ] && \
 		sed -i "s/const Version = \"$(VERSION)\"/const Version = \"$$newtag\"/" server.go && \
 		git add server.go && \


### PR DESCRIPTION
The `release` recipe sed-bumped the version in `server.go` and committed **before** `git tag`, with no pre-existence check. Re-running with an existing tag lands a dangling "Cut vX release" commit while `git tag` aborts — a half-published release.

Adds local (`git rev-parse --verify`) and remote (`git ls-remote --exit-code --tags`) tag guards after semver validation and before the confirm prompt / first mutation.

Verified: `make -n release` parses; feeding an existing tag to the recipe errors at the guard before any `sed`/commit/tag (no tags exist upstream, so a transient local-only tag was used to exercise the guard, then deleted). Tree stays clean.

Implements Safety Check #16 from the /makefile skill.